### PR TITLE
Add privacy-focused QA foundation

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,26 @@
+name: QA
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Compile
+        run: python -m compileall -q scripts tests
+      - name: Test
+        run: python -m unittest discover -s tests -v

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -26,6 +26,7 @@ jobs:
         run: python -m unittest discover -s tests -v
 
   browser-smoke:
+    # GitHub-hosted runners are disposable VMs; no real identity data is used here.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -24,3 +24,62 @@ jobs:
         run: python -m compileall -q scripts tests
       - name: Test
         run: python -m unittest discover -s tests -v
+
+  browser-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Start synthetic dashboard
+        run: |
+          demo_dir="${RUNNER_TEMP}/ryd-browser-demo"
+          python scripts/ryd.py serve --demo --workspace "${demo_dir}" \
+            >"${RUNNER_TEMP}/ryd-server.log" 2>&1 &
+          echo "$!" >"${RUNNER_TEMP}/ryd-server.pid"
+          for attempt in {1..20}; do
+            if curl --fail --silent http://127.0.0.1:8765/health; then
+              exit 0
+            fi
+            sleep 0.25
+          done
+          cat "${RUNNER_TEMP}/ryd-server.log"
+          exit 1
+      - name: Verify pages in headless Chrome
+        run: |
+          for route in report roster settings; do
+            case "${route}" in
+              report) url="http://127.0.0.1:8765/" ;;
+              *) url="http://127.0.0.1:8765/${route}" ;;
+            esac
+            google-chrome --headless --no-sandbox --disable-gpu \
+              --window-size=1440,1400 --dump-dom "${url}" \
+              >"${RUNNER_TEMP}/${route}.html"
+            google-chrome --headless --no-sandbox --disable-gpu \
+              --window-size=1440,1400 \
+              --screenshot="${RUNNER_TEMP}/${route}.png" "${url}"
+          done
+          grep --quiet "Jane Q. Public" "${RUNNER_TEMP}/report.html"
+          grep --quiet "Household roster" "${RUNNER_TEMP}/roster.html"
+          grep --quiet "Household routine" "${RUNNER_TEMP}/settings.html"
+      - name: Upload browser evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-smoke
+          path: |
+            ${{ runner.temp }}/report.html
+            ${{ runner.temp }}/report.png
+            ${{ runner.temp }}/roster.html
+            ${{ runner.temp }}/roster.png
+            ${{ runner.temp }}/settings.html
+            ${{ runner.temp }}/settings.png
+            ${{ runner.temp }}/ryd-server.log
+      - name: Stop dashboard
+        if: always()
+        run: |
+          if test -f "${RUNNER_TEMP}/ryd-server.pid"; then
+            kill "$(cat "${RUNNER_TEMP}/ryd-server.pid")" || true
+          fi

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -63,7 +63,7 @@ jobs:
           done
           grep --quiet "Jane Q. Public" "${RUNNER_TEMP}/report.html"
           grep --quiet "Household roster" "${RUNNER_TEMP}/roster.html"
-          grep --quiet "Household routine" "${RUNNER_TEMP}/settings.html"
+          grep --quiet "Scan routine" "${RUNNER_TEMP}/settings.html"
       - name: Upload browser evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@ exports/
 .env
 .env.*
 *.eml
+roster.md
+action-log.*
+leftovers.md
+serp-hosts.txt
+*.sqlite
+*.sqlite-wal
+*.sqlite-shm
 
 .DS_Store
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,9 @@ Use whatever this host already has. Do not install software they did not ask for
 | `CHANGELOG.md` | What shipped |
 
 `ryd.py` is stdlib-only. Do not add a dependency without a PR that says why. The skill still runs without Python (`SKILL.md` §0).
+
+## Code Review Rules
+
+- Treat consent and completed intake as data boundaries: no search pack or filing may include an inactive, unconfirmed, or intake-incomplete person.
+- Keep real PII outside the clone and keep the dashboard loopback-only by default; flag changes that expose workspace data, weaken browser-origin checks, or relax file permissions.
+- Keep `ryd.py` and its tests Python-stdlib-only unless a PR explicitly justifies a dependency. Deterministic checks belong in CI; live broker forms and real identities do not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,13 @@ First public drop. Agent-first skill + localhost app.
 - Harness fallbacks ([#4](https://github.com/k7cfo/remove-your-data/issues/4)): detect tools, use them, or coach. No Python → `templates/paper-log.md`. Missing browser/mail/scheduler degrades; do not refuse the job.
 - Localhost dashboard restyle ([#3](https://github.com/k7cfo/remove-your-data/issues/3)): knowsuchagency **Nothing** tokens (instrument panel, red interrupt, `light-dark`, theme toggle). Stdlib CSS only.
 - Scheduler ([#2](https://github.com/k7cfo/remove-your-data/issues/2)): detect what this host already uses; recommend one specific re-invoke. Not a catalog of products.
-- `RYD_PREVIEW=1` allows binding off loopback for a Tailscale-only demo. Default remains 127.0.0.1.
+- Stdlib-only QA suite and GitHub Actions matrix for Python 3.10–3.13: CLI, SQLite, consent boundaries, HTTP routes, security headers, exports, and registry parsing. CI uses synthetic data and never contacts a broker.
+- Dashboard hardening: same-origin POST checks, DNS-rebinding Host validation, CSP/security headers, safe URL rendering, private export modes, and off-loopback preview restricted to the built-in synthetic demo.
 
 ### Changed
 
 - README shots: report, roster, and settings from the Nothing dashboard (dark, sample household).
+- Search packs now require a completed primary intake, preserve explicit unconfirmed consent, exclude the defunct Open Data USA host, and report DROP status per person.
+- Evidence CSV exports include the complete household chronology, use deterministic ordering, and neutralize spreadsheet formulas.
 
 - Field notes: ContactOut Turnstile + `support@` fallback; TruePeopleSearch `.net` Google Form needs a signed-in consumer Google; Spokeo empty `/optout` → `privacy@`; Open Data USA null-MX / leftover vehicle cards / letter after the contact window / parked origin cancels the letter (confirm via browser + RDAP); origin timeout is not a drop; PeopleConnect name-index teasers can go quiet then resurface; curl CF vs browser can disagree; hourly CF after a live reading is opacity; Radaris city-only skip; ~90-day re-list clock; Whitepages Zendesk auto-ack may omit California (reply on the same thread); CheckPeople written expunge vs ~48h CF lag, then Google name-index can still snippet PII while origin is CF (do not refile); MyLife 410 can still SERP; National Public Data `/optout.html` Turnstile + `support@` fallback.
-

--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ Data brokers publish you. Paid “we'll delete you” apps mostly file the same 
 [AGPL-3.0-or-later](LICENSE). Free to use. If you ship a modified copy, or run a modified version as a network service, keep it AGPL and share the source. Contributions are inbound=outbound. Details in `LICENSE`.
 
 What changed: [`CHANGELOG.md`](CHANGELOG.md).
+
+## Development
+
+QA is Python-stdlib-only and uses temporary synthetic identities. It never contacts a broker or submits a live form.
+
+```bash
+python3 -m compileall -q scripts tests
+python3 -m unittest discover -s tests -v
+```
+
+GitHub Actions runs the same checks on Python 3.10–3.13. Real-data dashboards remain loopback-only; `RYD_PREVIEW=1` can expose only the built-in synthetic `--demo` workspace.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -21,7 +21,9 @@ Do not volunteer DOB, SSN, extra phones, or ID scans unless that form requires t
 - The git clone of this repo stays free of PII. Never commit `takedown.db`, paper logs, evidence, DROP IDs, listing slugs, phones, emails, or ticket numbers.
 - The workspace (`takedown.db` or `templates/paper-log.md` copies, `evidence/`, `exports/`) lives **outside** the clone. `chmod 700` workspace, `chmod 600` db if you have one.
 - Confirm pages, request IDs, DROP IDs, and mailbox contents stay in that private workspace (`action_log`, paper log, `email_event`, `evidence/YYYY-MM-DD/`).
-- The localhost dashboard binds `127.0.0.1` only.
+- A real-data dashboard binds `127.0.0.1` only. `RYD_PREVIEW=1` can bind off loopback only with the built-in synthetic `--demo` workspace.
+
+The SQLite workspace is not application-encrypted. Keep it on an encrypted, non-synced disk or encrypted home directory when the identifiers are sensitive.
 
 ## Roster allowlist
 

--- a/scripts/ryd.py
+++ b/scripts/ryd.py
@@ -242,14 +242,15 @@ def parse_cadence(raw: str) -> int:
     }
     if text in aliases:
         return aliases[text]
+    hours: int | None = None
     if text.endswith("d") and text[:-1].isdigit():
-        return int(text[:-1]) * 24
-    if text.endswith("h") and text[:-1].isdigit():
-        return int(text[:-1])
-    if text.isdigit():
+        hours = int(text[:-1]) * 24
+    elif text.endswith("h") and text[:-1].isdigit():
+        hours = int(text[:-1])
+    elif text.isdigit():
         hours = int(text)
-        if 1 <= hours <= 24 * 365:
-            return hours
+    if hours is not None and 1 <= hours <= 24 * 365:
+        return hours
     raise ValueError("Cadence must be like 7d, 24h, or an hour count.")
 
 
@@ -287,14 +288,17 @@ def apply_settings(con: sqlite3.Connection, fields: dict[str, str]) -> None:
 
 
 def init_workspace(workspace: Path) -> Path:
+    resolved = workspace.resolve()
+    if resolved == REPO or REPO in resolved.parents:
+        raise ValueError("Workspace must be outside this git clone.")
     workspace.mkdir(parents=True, exist_ok=True)
+    os.chmod(workspace, stat.S_IRWXU)
     (workspace / "evidence").mkdir(exist_ok=True)
     (workspace / "exports").mkdir(exist_ok=True)
     db = workspace / "takedown.db"
     with sqlite3.connect(db) as con:
         con.row_factory = sqlite3.Row
         migrate(con)
-    os.chmod(workspace, stat.S_IRWXU)
     os.chmod(db, stat.S_IRUSR | stat.S_IWUSR)
     return db
 
@@ -680,7 +684,6 @@ def scan_pack(idents: list[dict[str, Any]]) -> list[str]:
             "truepeoplesearch.com",
             "fastpeoplesearch.com",
             "beenverified.com",
-            "opendatausa.com",
             "peoplefinders.com",
             "nuwber.com",
             "thatsthem.com",
@@ -828,11 +831,6 @@ def load_report(
             )
         ]
     drop_filed = bool(person and person.get("drop_filed"))
-    if not drop_filed:
-        cfg = con.execute(
-            "SELECT value FROM config WHERE key = 'drop_filed'"
-        ).fetchone()
-        drop_filed = bool(cfg and cfg["value"] not in ("0", ""))
     next_due = None
     for clock in open_clocks:
         due = parse_utc(clock["due_at_utc"])
@@ -888,12 +886,17 @@ def cell(value: Any, url: bool = False) -> str:
     if value is None or value == "":
         return "<td class='empty'>—</td>"
     text = str(value)
-    if url and text.startswith("http"):
+    if url and safe_http_url(text):
         return (
-            f'<td><a href="{escape(text, quote=True)}" rel="noreferrer">'
+            f'<td><a href="{escape(text, quote=True)}" rel="noreferrer noopener">'
             f"{escape(text)}</a></td>"
         )
     return f"<td>{escape(text)}</td>"
+
+
+def safe_http_url(value: str) -> bool:
+    parsed = urlparse(value.strip())
+    return parsed.scheme.lower() in ("http", "https") and bool(parsed.hostname)
 
 
 def table(headers: list[str], rows: list[list[str]]) -> str:
@@ -956,12 +959,18 @@ def listing_cards(rows: list[dict[str, Any]]) -> str:
         meta = " · ".join(
             part for part in (row.get("pii_shown"), row.get("request_id")) if part
         )
-        href = escape(url, quote=True)
+        if safe_http_url(url):
+            url_html = (
+                f'<a class="item-url" href="{escape(url, quote=True)}" '
+                f'rel="noreferrer noopener">{escape(url)}</a>'
+            )
+        else:
+            url_html = f'<span class="item-url">{escape(url)}</span>'
         bits.append(
             f'<article class="item {escape(status)}">'
             f'<span class="rail"></span><div class="item-body">'
             f'<div class="item-head"><strong>{broker}</strong>{pill(status)}</div>'
-            f'<a class="item-url" href="{href}">{escape(url)}</a>'
+            f'{url_html}'
             f'<div class="item-meta">{escape(meta) if meta else " "}</div>'
             f"</div></article>"
         )
@@ -1202,7 +1211,14 @@ def render_html(report: dict[str, Any], *, live: bool, hero: bool = False) -> st
 """
 
 
-def render_csv(report: dict[str, Any]) -> str:
+def spreadsheet_safe(value: Any) -> str:
+    text = "" if value is None else str(value)
+    if text.lstrip().startswith(("=", "+", "-", "@")):
+        return "'" + text
+    return text
+
+
+def render_evidence_csv(con: sqlite3.Connection, person_id: int | None = None) -> str:
     fields = [
         "occurred_at_utc",
         "occurred_at_local",
@@ -1216,12 +1232,41 @@ def render_csv(report: dict[str, Any]) -> str:
         "result",
         "evidence_path",
     ]
+    sql = "SELECT " + ", ".join(fields) + " FROM v_evidence_chronology"
+    args: tuple[Any, ...] = ()
+    if person_id is not None:
+        sql += " WHERE person_id = ?"
+        args = (person_id,)
+    sql += " ORDER BY occurred_at_utc ASC, action_log_id ASC"
     buf = io.StringIO()
     writer = csv.writer(buf)
     writer.writerow(fields)
-    for row in reversed(report["log"]):
-        writer.writerow([row.get(k) or "" for k in fields])
+    for row in con.execute(sql, args):
+        writer.writerow([spreadsheet_safe(row[key]) for key in fields])
     return buf.getvalue()
+
+
+def refresh_family_intake(con: sqlite3.Connection, person_id: int) -> None:
+    person = con.execute(
+        "SELECT relationship, consent_basis FROM person WHERE id = ?",
+        (person_id,),
+    ).fetchone()
+    if not person or person["relationship"] == "self":
+        return
+    has_email = bool(
+        con.execute(
+            "SELECT 1 FROM identifier WHERE person_id = ? AND kind = 'email' LIMIT 1",
+            (person_id,),
+        ).fetchone()
+    )
+    complete = int(
+        has_email
+        and person["consent_basis"] in ("parent_of_minor", "authorized_agent")
+    )
+    con.execute(
+        "UPDATE person SET intake_complete = ? WHERE id = ?",
+        (complete, person_id),
+    )
 
 
 def add_identifier(con: sqlite3.Connection, person_id: int, kind: str, value: str) -> None:
@@ -1256,6 +1301,8 @@ def add_identifier(con: sqlite3.Connection, person_id: int, kind: str, value: st
         )
     except sqlite3.IntegrityError as exc:
         raise ValueError("Already on this person.") from exc
+    if kind == "email":
+        refresh_family_intake(con, person_id)
 
 
 def add_family_member(con: sqlite3.Connection, fields: dict[str, str]) -> int:
@@ -1271,8 +1318,6 @@ def add_family_member(con: sqlite3.Connection, fields: dict[str, str]) -> int:
     consent = fields.get("consent_basis", "unconfirmed")
     if consent not in CONSENT or consent == "self":
         consent = "unconfirmed"
-    if rel == "child" and consent == "unconfirmed":
-        consent = "parent_of_minor"
     primary = con.execute(
         "SELECT * FROM person WHERE relationship = 'self' ORDER BY id LIMIT 1"
     ).fetchone()
@@ -1287,7 +1332,7 @@ def add_family_member(con: sqlite3.Connection, fields: dict[str, str]) -> int:
           legal_name, residency_country, residency_region, timezone,
           cadence_hours, anonymity_mode, household_scope, relationship,
           consent_basis, active, drop_filed, intake_complete, created_at_utc
-        ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 1, 0, 1, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 1, 0, 0, ?)
         """,
         (name, country, region, tz, cadence, anon, rel, consent, utc_iso()),
     )
@@ -1308,6 +1353,8 @@ def apply_roster_post(con: sqlite3.Connection, fields: dict[str, str]) -> str:
             "SELECT person_id FROM identifier WHERE id = ?", (iid,)
         ).fetchone()
         con.execute("DELETE FROM identifier WHERE id = ?", (iid,))
+        if row:
+            refresh_family_intake(con, int(row["person_id"]))
         return f"/roster?p={row['person_id']}" if row else "/roster"
     if action == "toggle_scan":
         iid = int(fields.get("ident_id", "0"))
@@ -1335,6 +1382,7 @@ def apply_roster_post(con: sqlite3.Connection, fields: dict[str, str]) -> str:
         con.execute(
             "UPDATE person SET consent_basis = ? WHERE id = ?", (consent, pid)
         )
+        refresh_family_intake(con, pid)
         return f"/roster?p={pid}"
     raise ValueError("Unknown roster action.")
 
@@ -1600,6 +1648,12 @@ def cmd_pack(args: argparse.Namespace) -> int:
         for key, _how in load_dead_urls():
             print(f"# dead-url skip {key}")
         people = list_people(con)
+        primary = next(
+            (p for p in people if p.get("relationship") == "self"), None
+        )
+        if primary is None or not primary.get("intake_complete", 0):
+            print("# refusing search pack: primary intake is incomplete", file=sys.stderr)
+            return 1
         targets = people
         if args.person_id:
             targets = [p for p in people if p["id"] == args.person_id]
@@ -1608,6 +1662,9 @@ def cmd_pack(args: argparse.Namespace) -> int:
                 continue
             if person.get("consent_basis") == "unconfirmed":
                 print(f"# skip {person['legal_name']} (unconfirmed consent)", file=sys.stderr)
+                continue
+            if not person.get("intake_complete", 0):
+                print(f"# skip {person['legal_name']} (intake incomplete)", file=sys.stderr)
                 continue
             print(f"# {person['id']} {person['legal_name']} ({person.get('relationship')})")
             idents = list_idents(con, person["id"])
@@ -1661,12 +1718,58 @@ def report_from_db(db: Path, person_id: int | None = None) -> dict[str, Any]:
         return load_report(con, person_id)
 
 
+def write_private_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8", newline="") as stream:
+        stream.write(content)
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+
+
 def read_post(handler: BaseHTTPRequestHandler) -> dict[str, str]:
-    length = int(handler.headers.get("Content-Length") or 0)
-    if length > 64_000:
+    content_type = (handler.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+    if content_type != "application/x-www-form-urlencoded":
+        raise ValueError("Expected form-encoded POST")
+    try:
+        length = int(handler.headers.get("Content-Length") or 0)
+    except ValueError as exc:
+        raise ValueError("Invalid Content-Length") from exc
+    if length < 0 or length > 64_000:
         raise ValueError("POST too large")
     raw = handler.rfile.read(length).decode("utf-8", "replace")
     return {k: (v[0] if v else "") for k, v in parse_qs(raw, keep_blank_values=True).items()}
+
+
+def trusted_post_origin(handler: BaseHTTPRequestHandler) -> bool:
+    """Reject browser POSTs initiated by a different web origin.
+
+    The dashboard deliberately has no login because it is loopback-only. A hostile
+    website can still submit a cross-origin HTML form to localhost, so browser POSTs
+    must name the same origin as the request Host. Non-browser clients that omit both
+    Origin and Referer remain supported for local automation.
+    """
+    origin = (handler.headers.get("Origin") or "").strip()
+    if not origin:
+        referer = (handler.headers.get("Referer") or "").strip()
+        if referer:
+            parsed_referer = urlparse(referer)
+            if parsed_referer.scheme and parsed_referer.netloc:
+                origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
+    if not origin:
+        return True
+    parsed = urlparse(origin)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    request_host = (handler.headers.get("Host") or "").strip().lower()
+    return bool(request_host and parsed.netloc.lower() == request_host)
+
+
+def trusted_request_host(handler: BaseHTTPRequestHandler) -> bool:
+    if getattr(handler, "allow_remote_preview", False):
+        return True
+    raw = (handler.headers.get("Host") or "").strip()
+    parsed = urlparse("//" + raw)
+    return (parsed.hostname or "").lower() in ("127.0.0.1", "localhost", "::1")
 
 
 def person_query(qs: dict[str, list[str]]) -> int | None:
@@ -1679,6 +1782,7 @@ def person_query(qs: dict[str, list[str]]) -> int | None:
 
 class Handler(BaseHTTPRequestHandler):
     db_path: Path
+    allow_remote_preview = False
     server_version = "ryd-dashboard/0.1"
 
     def log_message(self, fmt: str, *args: Any) -> None:
@@ -1690,6 +1794,15 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
         self.send_header("X-Robots-Tag", "noindex")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'none'; style-src 'unsafe-inline'; "
+            "script-src 'unsafe-inline'; img-src 'self' data:; "
+            "form-action 'self'; frame-ancestors 'none'; base-uri 'none'",
+        )
         self.end_headers()
         self.wfile.write(body)
 
@@ -1699,10 +1812,15 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Location", location)
         self.send_header("Content-Length", "0")
         self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
         self.end_headers()
         self.wfile.write(body)
 
     def do_GET(self) -> None:  # noqa: N802
+        if not trusted_request_host(self):
+            self._send(403, b"untrusted Host header\n", "text/plain; charset=utf-8")
+            return
         parsed = urlparse(self.path)
         path = parsed.path
         qs = parse_qs(parsed.query)
@@ -1728,9 +1846,11 @@ class Handler(BaseHTTPRequestHandler):
             html = render_settings(report, flash=flash)
             self._send(200, html.encode("utf-8"), "text/html; charset=utf-8")
         elif path == "/export.csv":
+            with connect(self.db_path, readonly=True) as con:
+                body = render_evidence_csv(con, pid)
             self._send(
                 200,
-                render_csv(report).encode("utf-8"),
+                body.encode("utf-8"),
                 "text/csv; charset=utf-8",
             )
         elif path == "/health":
@@ -1739,8 +1859,14 @@ class Handler(BaseHTTPRequestHandler):
             self._send(404, b"not found\n", "text/plain; charset=utf-8")
 
     def do_POST(self) -> None:  # noqa: N802
-        if not preview_mode() and self.client_address[0] not in ("127.0.0.1", "::1"):
+        if not trusted_request_host(self):
+            self._send(403, b"untrusted Host header\n", "text/plain; charset=utf-8")
+            return
+        if not self.allow_remote_preview and self.client_address[0] not in ("127.0.0.1", "::1"):
             self._send(403, b"loopback only\n", "text/plain; charset=utf-8")
+            return
+        if not trusted_post_origin(self):
+            self._send(403, b"cross-origin POST refused\n", "text/plain; charset=utf-8")
             return
         parsed = urlparse(self.path)
         path = parsed.path
@@ -1777,27 +1903,44 @@ def preview_mode() -> bool:
     return os.environ.get("RYD_PREVIEW", "").strip().lower() in ("1", "true", "yes")
 
 
-def serve(db: Path, host: str, port: int) -> None:
+def serve(db: Path, host: str, port: int, *, allow_preview: bool = False) -> None:
     loopback = host in ("127.0.0.1", "localhost", "::1")
-    if not loopback and not preview_mode():
+    remote_preview = allow_preview and preview_mode()
+    if not loopback and not remote_preview:
         print(
             "Refusing to bind a PII dashboard off loopback. Use 127.0.0.1.",
             file=sys.stderr,
         )
         sys.exit(2)
+    if remote_preview:
+        with connect(db, readonly=True) as con:
+            sample = con.execute(
+                "SELECT value FROM config WHERE key = 'sample'"
+            ).fetchone()
+        if not sample or sample[0] in ("", "0"):
+            print(
+                "Refusing off-loopback preview: database is not synthetic demo data.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
     if not loopback:
         print(
-            "RYD_PREVIEW=1: binding off loopback. Publish only on Tailscale.",
+            "RYD_PREVIEW=1: exposing synthetic --demo data off loopback.",
             file=sys.stderr,
         )
     Handler.db_path = db
+    Handler.allow_remote_preview = remote_preview
     httpd = ThreadingHTTPServer((host, port), Handler)
     print(f"Dashboard http://{host}:{port}/  (db {db})", file=sys.stderr)
     httpd.serve_forever()
 
 
 def cmd_init(args: argparse.Namespace) -> int:
-    db = init_workspace(args.workspace)
+    try:
+        db = init_workspace(args.workspace)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
     print(db)
     return 0
 
@@ -1809,7 +1952,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
         with connect(db, readonly=False) as con:
             if con.execute("SELECT COUNT(*) FROM person").fetchone()[0] == 0:
                 seed_demo(con)
-        serve(db, args.host, args.port)
+        serve(db, args.host, args.port, allow_preview=True)
         return 0
     if not args.workspace:
         print("--workspace is required unless --demo", file=sys.stderr)
@@ -1826,18 +1969,17 @@ def cmd_export(args: argparse.Namespace) -> int:
     db = args.workspace / "takedown.db"
     report = report_from_db(db)
     out = args.out or (args.workspace / "exports" / "report.html")
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(render_html(report, live=False), encoding="utf-8")
+    write_private_text(out, render_html(report, live=False))
     print(out)
     return 0
 
 
 def cmd_export_csv(args: argparse.Namespace) -> int:
     db = args.workspace / "takedown.db"
-    report = report_from_db(db)
     out = args.out or (args.workspace / "exports" / "evidence-log.csv")
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(render_csv(report), encoding="utf-8")
+    with connect(db, readonly=True) as con:
+        content = render_evidence_csv(con)
+    write_private_text(out, content)
     print(out)
     return 0
 

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -130,6 +130,7 @@ CREATE INDEX IF NOT EXISTS idx_ident_person ON identifier(person_id, kind);
 
 CREATE VIEW IF NOT EXISTS v_evidence_chronology AS
 SELECT
+  a.id AS action_log_id,
   a.occurred_at_utc,
   a.occurred_at_local,
   a.actor,

--- a/tests/test_registry_pull.py
+++ b/tests/test_registry_pull.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("registry_pull", REPO / "scripts" / "registry_pull.py")
+assert SPEC and SPEC.loader
+registry_pull = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = registry_pull
+SPEC.loader.exec_module(registry_pull)
+
+
+class RegistryTests(unittest.TestCase):
+    def test_host_of(self) -> None:
+        self.assertEqual(registry_pull.host_of("https://www.Example.com/path"), "example.com")
+        self.assertEqual(registry_pull.host_of("privacy@example.org"), "example.org")
+        self.assertEqual(registry_pull.host_of("example.net/path"), "example.net")
+
+    def test_hosts_from_csv_uses_url_columns(self) -> None:
+        body = "Company,Website,Notes\nOne,https://one.example/path,ignore.example\nTwo,www.two.example,none\n"
+        self.assertEqual(registry_pull.hosts_from_csv(body), {"one.example", "two.example"})
+
+    def test_hosts_in_text(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="registry-test-") as tmp:
+            path = Path(tmp) / "brokers.md"
+            path.write_text("| Broker | https://www.example.com/optout |\nmail privacy@other.example\n", encoding="utf-8")
+            self.assertEqual(registry_pull.hosts_in_text(path), {"example.com", "other.example"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ryd.py
+++ b/tests/test_ryd.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import http.client
+import importlib.util
+import io
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+from urllib.parse import urlencode
+
+
+REPO = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("ryd", REPO / "scripts" / "ryd.py")
+assert SPEC and SPEC.loader
+ryd = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = ryd
+SPEC.loader.exec_module(ryd)
+
+
+def add_primary(
+    con: sqlite3.Connection,
+    *,
+    name: str = "Test Person",
+    intake_complete: int = 1,
+    drop_filed: int = 0,
+) -> int:
+    con.execute(
+        """
+        INSERT INTO person (
+          legal_name, residency_country, residency_region, timezone,
+          relationship, consent_basis, active, drop_filed, intake_complete,
+          created_at_utc
+        ) VALUES (?, 'US', 'CA', 'America/Los_Angeles', 'self', 'self', 1, ?, ?, ?)
+        """,
+        (name, drop_filed, intake_complete, ryd.utc_iso()),
+    )
+    pid = int(con.execute("SELECT last_insert_rowid()").fetchone()[0])
+    ryd.add_identifier(con, pid, "name", name)
+    return pid
+
+
+class WorkspaceCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory(prefix="ryd-test-")
+        self.workspace = Path(self.tmp.name) / "workspace"
+        self.db = ryd.init_workspace(self.workspace)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def connect(self, readonly: bool = False) -> sqlite3.Connection:
+        return ryd.connect(self.db, readonly=readonly)
+
+
+class UnitTests(unittest.TestCase):
+    def test_cadence_aliases_and_bounds(self) -> None:
+        for raw, expected in (("daily", 24), ("7d", 168), ("24h", 24), ("8760", 8760)):
+            with self.subTest(raw=raw):
+                self.assertEqual(ryd.parse_cadence(raw), expected)
+        for raw in ("0", "0h", "0d", "8761h", "366d", "-1", "nonsense"):
+            with self.subTest(raw=raw):
+                with self.assertRaises(ValueError):
+                    ryd.parse_cadence(raw)
+
+    def test_identifier_normalization(self) -> None:
+        self.assertEqual(ryd.normalize_ident("phone", "(916) 555-0142"), "9165550142")
+        self.assertEqual(ryd.normalize_ident("email", " A@Example.COM "), "a@example.com")
+        self.assertEqual(ryd.normalize_ident("keep_host", "https://www.LinkedIn.com/in/test"), "linkedin.com")
+
+    def test_safe_http_urls(self) -> None:
+        for value in ("https://example.com/a", "HTTP://example.com"):
+            self.assertTrue(ryd.safe_http_url(value))
+        for value in ("javascript:alert(1)", "data:text/html,x", "file:///tmp/x", "httpjavascript://x", "https://"):
+            self.assertFalse(ryd.safe_http_url(value))
+
+    def test_scan_pack_excludes_paused_keep_and_dead_host(self) -> None:
+        rows = [
+            {"kind": "name", "value": "Jane Public", "scan": 1},
+            {"kind": "phone", "value": "916-555-0142", "scan": 0},
+            {"kind": "keep_host", "value": "linkedin.com", "scan": 0},
+        ]
+        pack = ryd.scan_pack(rows)
+        self.assertIn('"Jane Public" site:spokeo.com', pack)
+        self.assertFalse(any("linkedin.com" in q for q in pack))
+        self.assertFalse(any("opendatausa.com" in q for q in pack))
+        self.assertFalse(any("9165550142" in q for q in pack))
+
+    def test_unsafe_listing_url_is_not_clickable(self) -> None:
+        html = ryd.listing_cards(
+            [{"status": "found", "broker": "Example", "url": "javascript:alert(1)", "pii_shown": None, "request_id": None}]
+        )
+        self.assertNotIn('href="javascript:', html)
+        self.assertIn("javascript:alert(1)", html)
+
+
+class WorkspaceTests(WorkspaceCase):
+    def test_init_is_idempotent_private_and_complete(self) -> None:
+        self.assertEqual(stat.S_IMODE(self.workspace.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(self.db.stat().st_mode), 0o600)
+        ryd.init_workspace(self.workspace)
+        with self.connect() as con:
+            names = {r[0] for r in con.execute("SELECT name FROM sqlite_master")}
+        self.assertTrue({"person", "identifier", "listing", "clock", "v_evidence_chronology"} <= names)
+
+    def test_workspace_inside_clone_is_refused(self) -> None:
+        target = REPO / "privacy-takedown-test"
+        with self.assertRaisesRegex(ValueError, "outside this git clone"):
+            ryd.init_workspace(target)
+        self.assertFalse(target.exists())
+
+    def test_real_workspace_cannot_preview_off_loopback(self) -> None:
+        with mock.patch.dict(os.environ, {"RYD_PREVIEW": "1"}, clear=False):
+            with self.assertRaises(SystemExit) as raised:
+                ryd.serve(self.db, "0.0.0.0", 0, allow_preview=True)
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_child_unconfirmed_consent_is_not_fabricated(self) -> None:
+        with self.connect() as con:
+            add_primary(con)
+            child = ryd.add_family_member(
+                con,
+                {"legal_name": "Adult Child", "relationship": "child", "consent_basis": "unconfirmed"},
+            )
+            con.commit()
+            row = con.execute("SELECT consent_basis FROM person WHERE id = ?", (child,)).fetchone()
+        self.assertEqual(row[0], "unconfirmed")
+
+    def test_pack_refuses_incomplete_primary(self) -> None:
+        with self.connect() as con:
+            add_primary(con, intake_complete=0)
+            con.commit()
+        args = argparse.Namespace(workspace=self.workspace, person_id=None)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            result = ryd.cmd_pack(args)
+        self.assertEqual(result, 1)
+        self.assertIn("primary intake is incomplete", err.getvalue())
+
+    def test_pack_skips_unconfirmed_family(self) -> None:
+        with self.connect() as con:
+            add_primary(con)
+            ryd.add_family_member(
+                con,
+                {"legal_name": "No Consent", "relationship": "spouse", "consent_basis": "unconfirmed"},
+            )
+            con.commit()
+        args = argparse.Namespace(workspace=self.workspace, person_id=None)
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            result = ryd.cmd_pack(args)
+        self.assertEqual(result, 0)
+        self.assertNotIn('"No Consent"', out.getvalue())
+        self.assertIn("unconfirmed consent", err.getvalue())
+
+    def test_family_intake_requires_consent_and_unique_email(self) -> None:
+        with self.connect() as con:
+            add_primary(con)
+            family = ryd.add_family_member(
+                con,
+                {"legal_name": "Authorized Family", "relationship": "spouse", "consent_basis": "authorized_agent"},
+            )
+            before = con.execute(
+                "SELECT intake_complete FROM person WHERE id = ?", (family,)
+            ).fetchone()[0]
+            ryd.add_identifier(con, family, "email", "family@example.com")
+            after = con.execute(
+                "SELECT intake_complete FROM person WHERE id = ?", (family,)
+            ).fetchone()[0]
+            con.commit()
+        self.assertEqual(before, 0)
+        self.assertEqual(after, 1)
+
+    def test_drop_status_is_per_person(self) -> None:
+        with self.connect() as con:
+            primary = add_primary(con, drop_filed=1)
+            child = ryd.add_family_member(
+                con,
+                {"legal_name": "Child", "relationship": "child", "consent_basis": "parent_of_minor"},
+            )
+            con.execute("INSERT INTO config (key, value) VALUES ('drop_filed', '1')")
+            con.commit()
+            self.assertTrue(ryd.load_report(con, primary)["drop_filed"])
+            self.assertFalse(ryd.load_report(con, child)["drop_filed"])
+
+    def test_evidence_csv_is_complete_ordered_and_formula_safe(self) -> None:
+        with self.connect() as con:
+            first = add_primary(con)
+            second = ryd.add_family_member(
+                con,
+                {"legal_name": "Second Person", "relationship": "spouse", "consent_basis": "authorized_agent"},
+            )
+            for index in range(205):
+                pid = first if index % 2 == 0 else second
+                con.execute(
+                    """
+                    INSERT INTO action_log (
+                      person_id, actor, action, result, occurred_at_utc, occurred_at_local
+                    ) VALUES (?, 'agent', ?, ?, ?, ?)
+                    """,
+                    (pid, f"action-{index:03d}", "=HYPERLINK(\"bad\")" if index == 0 else "ok", f"2026-01-01T00:{index // 60:02d}:{index % 60:02d}Z", "local"),
+                )
+            con.commit()
+            rows = list(csv.DictReader(io.StringIO(ryd.render_evidence_csv(con))))
+        self.assertEqual(len(rows), 205)
+        self.assertEqual({row["person"] for row in rows}, {"Test Person", "Second Person"})
+        self.assertTrue(rows[0]["result"].startswith("'="))
+        self.assertEqual(rows[0]["action"], "action-000")
+
+    def test_exports_are_private(self) -> None:
+        with self.connect() as con:
+            add_primary(con)
+            con.commit()
+        old_umask = os.umask(0o022)
+        try:
+            self.assertEqual(ryd.cmd_export(argparse.Namespace(workspace=self.workspace, out=None)), 0)
+            self.assertEqual(ryd.cmd_export_csv(argparse.Namespace(workspace=self.workspace, out=None)), 0)
+        finally:
+            os.umask(old_umask)
+        for path in (self.workspace / "exports" / "report.html", self.workspace / "exports" / "evidence-log.csv"):
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+
+class HttpTests(WorkspaceCase):
+    def setUp(self) -> None:
+        super().setUp()
+        with self.connect() as con:
+            add_primary(con)
+            con.commit()
+        ryd.Handler.db_path = self.db
+        ryd.Handler.allow_remote_preview = False
+        self.server = ryd.ThreadingHTTPServer(("127.0.0.1", 0), ryd.Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.port = int(self.server.server_address[1])
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        super().tearDown()
+
+    def request(self, method: str, path: str, body: str | None = None, headers: dict[str, str] | None = None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=3)
+        conn.request(method, path, body=body, headers=headers or {})
+        response = conn.getresponse()
+        payload = response.read()
+        result = response.status, {k.lower(): v for k, v in response.getheaders()}, payload
+        conn.close()
+        return result
+
+    def test_routes_and_security_headers(self) -> None:
+        for path in ("/", "/roster", "/settings", "/export.csv", "/health"):
+            with self.subTest(path=path):
+                status, headers, _ = self.request("GET", path)
+                self.assertEqual(status, 200)
+                self.assertEqual(headers["cache-control"], "no-store")
+                self.assertEqual(headers["x-content-type-options"], "nosniff")
+                self.assertEqual(headers["referrer-policy"], "no-referrer")
+        _, headers, _ = self.request("GET", "/")
+        self.assertIn("frame-ancestors 'none'", headers["content-security-policy"])
+
+    def test_foreign_origin_post_is_refused(self) -> None:
+        body = urlencode({"cadence_hours": "24", "anonymity_mode": "dedicated", "timezone": "UTC", "refresh_seconds": "30"})
+        status, _, payload = self.request(
+            "POST",
+            "/settings",
+            body,
+            {"Content-Type": "application/x-www-form-urlencoded", "Origin": "https://evil.example"},
+        )
+        self.assertEqual(status, 403)
+        self.assertIn(b"cross-origin", payload)
+
+    def test_same_origin_post_succeeds(self) -> None:
+        host = f"127.0.0.1:{self.port}"
+        body = urlencode({"cadence_hours": "24", "anonymity_mode": "dedicated", "timezone": "UTC", "refresh_seconds": "30"})
+        status, headers, _ = self.request(
+            "POST",
+            "/settings",
+            body,
+            {"Host": host, "Origin": f"http://{host}", "Content-Type": "application/x-www-form-urlencoded"},
+        )
+        self.assertEqual(status, 303)
+        self.assertEqual(headers["location"], "/settings?ok=Saved.")
+
+    def test_dns_rebinding_host_is_refused(self) -> None:
+        status, _, payload = self.request("GET", "/", headers={"Host": "evil.example"})
+        self.assertEqual(status, 403)
+        self.assertIn(b"untrusted Host", payload)
+
+
+class CliSmokeTests(unittest.TestCase):
+    def test_cli_init_settings_and_exports(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ryd-cli-") as tmp:
+            workspace = Path(tmp) / "workspace"
+            script = REPO / "scripts" / "ryd.py"
+            init = subprocess.run(
+                [sys.executable, str(script), "init", "--workspace", str(workspace)],
+                cwd=REPO,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(init.returncode, 0, init.stderr)
+            show = subprocess.run(
+                [sys.executable, str(script), "settings", "--workspace", str(workspace), "--show"],
+                cwd=REPO,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(show.returncode, 0, show.stderr)
+            self.assertIn("cadence_hours=168", show.stdout)
+
+    def test_demo_flag_cannot_expose_existing_real_workspace(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ryd-cli-") as tmp:
+            workspace = Path(tmp) / "workspace"
+            db = ryd.init_workspace(workspace)
+            with ryd.connect(db, readonly=False) as con:
+                add_primary(con)
+                con.commit()
+            env = dict(os.environ)
+            env["RYD_PREVIEW"] = "1"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "scripts" / "ryd.py"),
+                    "serve",
+                    "--demo",
+                    "--workspace",
+                    str(workspace),
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "0",
+                ],
+                cwd=REPO,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("not synthetic demo data", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Python-stdlib-only QA suite and GitHub Actions matrix for Python 3.10–3.13
- enforce primary/family intake and explicit consent before search-pack generation
- prevent real workspaces from using the off-loopback synthetic demo escape hatch
- add Origin and Host validation plus CSP and privacy-oriented response headers
- make evidence CSV exports complete, deterministic, spreadsheet-safe, and mode 0600
- reject unsafe listing URL schemes and workspaces created inside the git clone
- add repository-specific Codex review rules

## Validation

- `python3 -m compileall -q scripts tests`
- `python3 -m unittest discover -s tests -v` — 24 tests passed
- skill quick validator passed
- `git diff --check` passed
- independent forward review passed consent, preview isolation, HTTP, export, and permission probes

All tests use temporary synthetic identities. CI performs no live broker requests or form submissions.